### PR TITLE
importing system: handle return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Changed string of classes from default to `<class 'NameOfClass'>` (GH-108)
 
 #### New Features
-- Handle `return` in importing system by `import()` ([read the doc](doc/05_importing/02_return_value.md))
+- Handle `return` in importing system by `import()` ([read the doc](doc/05_importing/02_return_value.md)) (GH-109)
 
 ## 0.7.2 (2021-2-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 #### Changes
 - Changed string of classes from default to `<class 'NameOfClass'>` (GH-108)
 
+#### New Features
+- Handle `return` in importing system by `import()` ([read the doc](doc/05_importing/02_return_value.md))
+
 ## 0.7.2 (2021-2-16)
 
 #### New Features

--- a/doc/05_importing/02_return_value.md
+++ b/doc/05_importing/02_return_value.md
@@ -1,0 +1,27 @@
+# Script return value
+Scripts can return some values (like functions).
+
+For example, we have `foo.pashm`:
+
+```bash
+# ...
+
+return 'hello world'
+```
+
+Now, if i import this file:
+
+```bash
+$output = import('foo.pashm')
+
+println 'output: ' + $output
+```
+
+Output:
+
+```
+output: hello world
+```
+
+As you can see, function `import` (or `import_once`, `import_run`...) will return the returned value
+by command `return` in the script. By this feature, we can return values by scripts like functions.

--- a/doc/05_importing/README.md
+++ b/doc/05_importing/README.md
@@ -2,3 +2,4 @@
 
 - [Importing scripts](00_include_scripts.md)
 - [$__ismain__ variable](01_ismain_variable.md)
+- [Script return value](02_return_value.md)

--- a/src/core/program.py
+++ b/src/core/program.py
@@ -165,6 +165,7 @@ class Program(helpers.Helpers):
                     return self.raise_error('FileError', str(ex), op)
 
             self.exec_func(commands, False)
+        return self.get_mem()
 
     def set_commands(self, commands: list):
         """ Set commands list """

--- a/tests/test-module-path/bar.pashm
+++ b/tests/test-module-path/bar.pashm
@@ -1,0 +1,2 @@
+$name = 'parsa'
+return $name

--- a/tests/test-module-path/foo.pashmt
+++ b/tests/test-module-path/foo.pashmt
@@ -1,0 +1,31 @@
+#
+# foo.pashmt
+#
+# The Pashmak Project
+# Copyright 2020-2021 parsa shahmaleki <parsampsh@gmail.com>
+#
+# This file is part of Pashmak.
+#
+# Pashmak is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Pashmak is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pashmak.  If not, see <https://www.gnu.org/licenses/>.
+#########################################################################
+
+--test--
+script returned value will be returned by import()
+
+--file--
+
+println import_once($__dir__ + '/tests/test-module-path/bar.pashm')
+
+--output--
+"parsa\n"


### PR DESCRIPTION
With this feature we can return values by scripts and import them:

```bash
return 'hello'
```

```bash
$output = import('script.pashm')
println $output # hello
```