### PR TITLE
Create keyword "end" for closing the blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added module `regex` (GH-129)
 - Added `$os.pwd` variable in `os` module (GH-158)
 - Added *Traits* for OOP system (GH-164, GH-165)
+- Added keyword `end` to close blocks instead of `endif`, `endwhile`... previous keywords still work (GH-171)
 
 ## 0.8.5 (2021-5-31)
 

--- a/doc/01_if_and_loop/01_if_statement.md
+++ b/doc/01_if_and_loop/01_if_statement.md
@@ -56,6 +56,16 @@ endif
 # above code haven't output
 ```
 
+Also you can use keyword `end` instead of `endif`:
+
+```bash
+$age = 12
+
+if $age > 18
+    println('Welcome!')
+end
+```
+
 also you can use `else`:
 
 ```bash

--- a/doc/01_if_and_loop/02_while_loop.md
+++ b/doc/01_if_and_loop/02_while_loop.md
@@ -39,6 +39,8 @@ output:
 10
 ```
 
+Note: you can use keyword `end` instead of `endwhile`. It is not different.
+
 Also you learned about loops in the **labels** part. The `while` loop makes the syntax easier.
 
 Structure of while loop:

--- a/doc/02_functions/00_functions.md
+++ b/doc/02_functions/00_functions.md
@@ -10,6 +10,8 @@ endfunc
 say_hello()
 ```
 
+Note: you can use keyword `end` instead of `endif`. It is not different.
+
 output:
 
 ```

--- a/doc/03_try_endtry/00_try_and_endtry.md
+++ b/doc/03_try_endtry/00_try_and_endtry.md
@@ -51,6 +51,8 @@ label after_error
 when you write code between `try <label-name> ... endtry`, errors will not raised in them and if an error is raised, that label where passed to try command will run.
 actually, we say to the Pashmak to don't show error to user and do that thing I'm saying you instead of default error showing.
 
+Note: you can ue keyword `end` instead of `endtry`. It is not different.
+
 ### how to access raised error data?
 
 when error is raised in try statement, error data will put in mem (^):

--- a/doc/06_namespaces/00_namespaces.md
+++ b/doc/06_namespaces/00_namespaces.md
@@ -16,6 +16,8 @@ endnamespace
 App.say_hello
 ```
 
+Note: you can use keyword `end` instead of `endnamespace`. It is not different.
+
 output:
 
 ```

--- a/doc/08_class_and_oop/00_classes.md
+++ b/doc/08_class_and_oop/00_classes.md
@@ -10,6 +10,8 @@ class Car
 endclass
 ```
 
+Note: you can use keyword `end` instead of `endclass`. It is not different.
+
 in above example, we declared a class named `Car` with `name` and `color` properties.
 
 let's use this:

--- a/src/core/parser.py
+++ b/src/core/parser.py
@@ -169,6 +169,22 @@ def parse(content: str, filepath='<system>', only_parse=False, no_random=False) 
     if only_parse:
         return commands
 
+    # handle the "end" keyword
+    i = 0
+    started_blocks = []
+    while i < len(commands):
+        if commands[i]['command'] in ('if', 'while', 'try', 'namespace', 'class', 'func', 'ns'):
+            started_blocks.append(commands[i]['command'])
+        elif commands[i]['command'] in ('endif', 'endwhile', 'endtry', 'endnamespace', 'endclass', 'endfunc'):
+            start_command = commands[i]['command'][3:]
+            if started_blocks and started_blocks[-1] == start_command:
+                started_blocks.pop(-1)
+        elif commands[i]['command'] == 'end':
+            if started_blocks:
+                started_block = started_blocks.pop(-1)
+                commands[i]['command'] = 'end' + started_block
+        i += 1
+
     # handle the if statement
     open_ifs = []
     open_ifs_counters = []

--- a/src/core/program.py
+++ b/src/core/program.py
@@ -444,6 +444,7 @@ class Program(helpers.Helpers):
             'elif': None,
             'else': None,
             'endif': None,
+            'end': None,
         }
 
         # check op_name is a valid command

--- a/tests/core/test.pashmt
+++ b/tests/core/test.pashmt
@@ -1,0 +1,137 @@
+#
+# test.pashmt
+#
+# The Pashmak Project
+# Copyright 2020-2021 parsa shahmaleki <parsampsh@gmail.com>
+#
+# This file is part of Pashmak.
+#
+# Pashmak is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Pashmak is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pashmak.  If not, see <https://www.gnu.org/licenses/>.
+#########################################################################
+
+--test--
+Keyword "end" works correctly for all types of started blocks
+
+--file--
+
+$i = 20
+$x = 10
+
+if $i < $x
+    println 'yes'
+else
+    println 'no'
+
+    if $i == 2001
+        println 'A'
+    else
+        if $x == 9
+            println 'B'
+        else
+            println 'C'
+        end
+    endif
+end
+
+func hello($x, $i)
+    while $x < $i
+        println $x
+
+        $x = $x + 1
+
+        $z = 0
+        while $z < 3
+            println 'z' + str($z)
+            $z = $z + 1
+        end
+    endwhile
+end
+
+hello($x, $i)
+
+class Person
+    func hi()
+        println 'hello'
+    end
+
+    func bye()
+        println 'bye'
+    endfunc
+end
+
+if true
+    if true
+        $p = Person()
+        $p->hi()
+        $p->bye()
+    end
+endif
+
+namespace A
+    ns B
+        func tst()
+            println 'tst'
+        endfunc
+    end
+end
+
+A.B.tst()
+
+--output--
+"""no
+C
+10
+z0
+z1
+z2
+11
+z0
+z1
+z2
+12
+z0
+z1
+z2
+13
+z0
+z1
+z2
+14
+z0
+z1
+z2
+15
+z0
+z1
+z2
+16
+z0
+z1
+z2
+17
+z0
+z1
+z2
+18
+z0
+z1
+z2
+19
+z0
+z1
+z2
+hello
+bye
+tst
+"""


### PR DESCRIPTION
Now you are able to use keyword `end` instead of `endif`, `endwhile`... for closing the blocks.
An example:

```bash
if something
    while other
    end

    func filan()
        if a
        end
    end
end
```

The important note is that you can still use previous keywords (endif, endfunc...):

```bash
while true
    if something
    end
endwhile
```

You can see we have used `end` to close if block and `endwhile` (old keyword) to close while block.

This PR is not complete yet. I'm working on it. But technically it's ready.

Any feedback?